### PR TITLE
Allow alt text to be customized via options

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -373,7 +373,7 @@
 			this._oContext = this._elCanvas.getContext("2d");
 			this._bIsPainted = false;
 			this._elImage = document.createElement("img");
-			this._elImage.alt = "Scan me!";
+			this._elImage.alt = htOption.altText ? htOption.altText : "Scan me!";
 			this._elImage.style.display = "none";
 			this._el.appendChild(this._elImage);
 			this._bSupportDataURI = null;


### PR DESCRIPTION
# Lore

Me and @nmacneil went on a wild goose chase in portal one for where this string was being defined, little did we know it wasn't even in Bitbucket land, it sit in the depths of _Github_.

# What

Allow the alt text to be customized, will default to what it was before if no altText option defined.

# Test

Check terniary is is _good_, will not break backwards complataibility in anyway, since existing references to this project don't seem to be pinned/versioned in anyway.
